### PR TITLE
Configure and makefile updated to use opam depext and specify that icc/gcc/clang are not mandatory.

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,2 @@
 profile = default
-version = 0.20.1
+version = 0.21.0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean
+.PHONY: all clean configure
 
 # Directories
 SRC_DIR := src
@@ -12,12 +12,20 @@ DUNE := dune
 MAIN := main
 
 all:
+	@if [ ! -f ./src/config.ml ]; then \
+		echo "config.ml was not found.";\
+		echo "./configure will be executed but you can/should rerun it if your directories are not located in the same places"; \
+		./configure; \
+	fi
+	@echo $(FILE_EXISTS)
 	$(DUNE) build
 	chmod +w _build/default/bin/cli/main.exe
 	cp _build/default/bin/cli/main.exe usubac
 
 # ./main.native -tests
 # cp main.native ../usubac
+
+configure:
 
 clean:
 	rm -f *~ .*~ usubac

--- a/src/tightprove/print_tp.ml
+++ b/src/tightprove/print_tp.ml
@@ -25,8 +25,7 @@ let asgn_to_str (asgn : asgn) : string =
   sprintf "%s = %s\n" asgn.lhs (expr_to_str asgn.rhs)
 
 let def_to_str (def : def) : string =
-  sprintf "rs=%d\n\n%s\n\n%s\n" (* m *)
-    def.rs
+  sprintf "rs=%d\n\n%s\n\n%s\n" (* m *) def.rs
     (* inputs *)
     (join "" (List.map (sprintf "in %s\n") def.inputs))
     (* body *)

--- a/src/tightprove/tp_AST.ml
+++ b/src/tightprove/tp_AST.ml
@@ -7,7 +7,8 @@ type expr =
   | Const of int
   | ConstAll of int
   | Refresh of string
-  | BitToReg of string * int (* useful for Pyjamask: -1 if string.int == 1; 0 otherwise *)
+  | BitToReg of
+      string * int (* useful for Pyjamask: -1 if string.int == 1; 0 otherwise *)
   | Not of string
   | Log of log_op * string * string
   | Shift of shift_op * string * int


### PR DESCRIPTION
QoL: ./configure will be executed when using make if src/config.ml is not found. If you build with dune build without ./configure first, that's not our problem.

Should fix #13 

cc @odiferousmint