### PR TITLE
Fixed relative pathing leading to a silent bug

### DIFF
--- a/bin/cli/main.ml
+++ b/bin/cli/main.ml
@@ -1,6 +1,5 @@
 open Usuba_lib
 open Usuba_AST
-open Basic_utils
 open Utils
 open Usuba_pp
 
@@ -77,9 +76,9 @@ let bits_in_arch = function
   | AltiVec -> 128
 
 let gen_output_filename ?(ext = ".c") file_in =
-  let full_name = List.hd (String.split_on_char '.' file_in) in
-  let out_name = last (String.split_on_char '/' full_name) in
-  out_name ^ ext
+  match Filename.chop_suffix_opt ~suffix:".ua" Filename.(basename file_in) with
+  | None -> failwith "You didn't provide a file suffixed with '.ua'"
+  | Some base -> base ^ ext
 
 let compile (file_in : string) (prog : Usuba_AST.prog) (conf : config) : unit =
   (* Type-checking *)
@@ -94,7 +93,8 @@ let compile (file_in : string) (prog : Usuba_AST.prog) (conf : config) : unit =
   | true ->
       let out = open_out (gen_output_filename ~ext:".ua0" file_in) in
       let ppf = Format.formatter_of_out_channel out in
-      Format.fprintf ppf "%a" Sexplib.Sexp.pp_hum (Usuba_AST.sexp_of_prog normed_prog);
+      Format.fprintf ppf "%a" Sexplib.Sexp.pp_hum
+        (Usuba_AST.sexp_of_prog normed_prog);
       close_out out
   | false ->
       (* Generating a string of C code *)


### PR DESCRIPTION
This bug was already here before using dump-sexp, it actually appeared because with how we reorganised the repositories and benchs being outside of usuba, we finally used "../*" to provide usuba files. Nice catch!