### PR TITLE
Fixed compiling the files as soon as we see them on the command line

### DIFF
--- a/bin/cli/main.ml
+++ b/bin/cli/main.ml
@@ -345,6 +345,11 @@ let main () =
     compile s prog conf
   in
 
-  Arg.parse speclist compile usage_msg
+  let input_files = ref [] in
+  let anon_fun filename = input_files := filename :: !input_files in
+
+  Arg.parse speclist anon_fun usage_msg;
+
+  List.iter (fun file -> compile file) !input_files
 
 let () = main ()


### PR DESCRIPTION
If you write `./usubac file -o output` the file wouldn't be written to output because -o appeared after the file. 
The same would happen for any option provided after the file leading to silent buggy behaviours.