### PR TITLE
Loop now contains an inline record

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ observations.org
 
 # Unit tests submodule
 unit_tests/
+
+fix_all_params.ml

--- a/src/c_gen/nodes_to_c.ml
+++ b/src/c_gen/nodes_to_c.ml
@@ -177,15 +177,15 @@ let rec deqs_to_c (lift_env : int VarHashtbl.t)
              let m = Utils.get_type_m (Utils.get_var_type env_var v) in
              Format.sprintf "%s%s = %s;" tabs (var_to_c lift_env env v)
                (expr_to_c m lift_env env env_var e)
-         | Loop (i, ei, ef, l, _) ->
+         | Loop { id; start; stop; body; _ } ->
              Format.sprintf "%sfor (int %s = %s; %s <= %s; %s++) {\n%s\n%s}"
                tabs
-               (rename (Ident.name i))
-               (aexpr_to_c ei)
-               (rename (Ident.name i))
-               (aexpr_to_c ef)
-               (rename (Ident.name i))
-               (deqs_to_c lift_env env env_var ~tabs:(tabs ^ "  ") l)
+               (rename (Ident.name id))
+               (aexpr_to_c start)
+               (rename (Ident.name id))
+               (aexpr_to_c stop)
+               (rename (Ident.name id))
+               (deqs_to_c lift_env env env_var ~tabs:(tabs ^ "  ") body)
                tabs
          | _ ->
              Format.eprintf "%a@." (Usuba_print.pp_deq ()) deq;

--- a/src/c_gen/nodes_to_c_fdti.ml
+++ b/src/c_gen/nodes_to_c_fdti.ml
@@ -183,15 +183,15 @@ let rec deqs_to_c (lift_env : int VarHashtbl.t)
              Format.sprintf "%s%s;" tabs
                (expr_to_c_ret lift_env conf env env_var
                   (var_to_c lift_env env v) e)
-         | Loop (i, ei, ef, l, _) ->
+         | Loop { id; start; stop; body; _ } ->
              Format.sprintf "%sfor (int %s = %s; %s <= %s; %s++) {\n%s\n%s}"
                tabs
-               (rename (Ident.name i))
-               (aexpr_to_c ei)
-               (rename (Ident.name i))
-               (aexpr_to_c ef)
-               (rename (Ident.name i))
-               (deqs_to_c lift_env env env_var l ~tabs:(tabs ^ "  ") conf)
+               (rename (Ident.name id))
+               (aexpr_to_c start)
+               (rename (Ident.name id))
+               (aexpr_to_c stop)
+               (rename (Ident.name id))
+               (deqs_to_c lift_env env env_var body ~tabs:(tabs ^ "  ") conf)
                tabs
          | _ ->
              Format.eprintf "%a@." (Usuba_print.pp_deq ()) deq;

--- a/src/c_gen/nodes_to_c_masked.ml
+++ b/src/c_gen/nodes_to_c_masked.ml
@@ -197,15 +197,16 @@ let rec deqs_to_c (env_const : bool Ident.Hashtbl.t)
              | _ ->
                  Format.sprintf "%s%s;" tabs
                    (expr_to_c_ret env_const lift_env env env_var v e))
-         | Loop (i, ei, ef, l, _) ->
+         | Loop { id; start; stop; body; _ } ->
              Format.sprintf "%sfor (int %s = %s; %s <= %s; %s++) {@.%s@.%s}"
                tabs
-               (rename (Ident.name i))
-               (aexpr_to_c ei)
-               (rename (Ident.name i))
-               (aexpr_to_c ef)
-               (rename (Ident.name i))
-               (deqs_to_c env_const lift_env env env_var ~tabs:(tabs ^ "  ") l)
+               (rename (Ident.name id))
+               (aexpr_to_c start)
+               (rename (Ident.name id))
+               (aexpr_to_c stop)
+               (rename (Ident.name id))
+               (deqs_to_c env_const lift_env env env_var ~tabs:(tabs ^ "  ")
+                  body)
                tabs
          | _ ->
              Format.eprintf "%a@." (Usuba_print.pp_deq ()) deq;

--- a/src/c_gen/nodes_to_c_ua_masked.ml
+++ b/src/c_gen/nodes_to_c_ua_masked.ml
@@ -184,15 +184,15 @@ let rec deqs_to_c (lift_env : int VarHashtbl.t)
              | _ ->
                  Format.sprintf "%s%s;" tabs
                    (expr_to_c_ret lift_env env env_var v e))
-         | Loop (i, ei, ef, l, _) ->
+         | Loop { id; start; stop; body; _ } ->
              Format.sprintf "%sfor (int %s = %s; %s <= %s; %s++) {\n%s\n%s}"
                tabs
-               (rename (Ident.name i))
-               (aexpr_to_c ei)
-               (rename (Ident.name i))
-               (aexpr_to_c ef)
-               (rename (Ident.name i))
-               (deqs_to_c lift_env env env_var ~tabs:(tabs ^ "  ") l)
+               (rename (Ident.name id))
+               (aexpr_to_c start)
+               (rename (Ident.name id))
+               (aexpr_to_c stop)
+               (rename (Ident.name id))
+               (deqs_to_c lift_env env env_var ~tabs:(tabs ^ "  ") body)
                tabs
          | _ ->
              Format.eprintf "%a@." (Usuba_print.pp_deq ()) deq;

--- a/src/clear_origins.ml
+++ b/src/clear_origins.ml
@@ -19,7 +19,7 @@ let rec clear_deqs (deqs : deq list) : deq list =
         content =
           (match d.content with
           | Eqn _ -> d.content
-          | Loop (i, ei, ef, dl, opts) -> Loop (i, ei, ef, clear_deqs dl, opts));
+          | Loop t -> Loop { t with body = clear_deqs t.body });
       })
     deqs
 

--- a/src/normalization/clean.ml
+++ b/src/normalization/clean.ml
@@ -36,7 +36,7 @@ let clean_in_deqs (vars : p) (deqs : deq list) : p =
     | Eqn (l, e, _) ->
         List.iter (collect_var env) l;
         collect_expr env e
-    | Loop (_, _, _, d, _) -> List.iter aux d
+    | Loop { body; _ } -> List.iter aux body
   in
   List.iter aux deqs;
   List.sort_uniq compare_var_d

--- a/src/normalization/fix_dim.ml
+++ b/src/normalization/fix_dim.ml
@@ -145,8 +145,8 @@ let rec dim_deq (v_tgt : var) (dim : int) (size : int) (deq : deq) : deq =
             ( List.map (dim_var v_tgt dim size) vs,
               dim_expr v_tgt dim size e,
               sync )
-      | Loop (i, ei, ef, dl, opts) ->
-          Loop (i, ei, ef, List.map (dim_deq v_tgt dim size) dl, opts));
+      | Loop t ->
+          Loop { t with body = List.map (dim_deq v_tgt dim size) t.body });
   }
 
 (* Merges the two innermost dimensions of |t|. For instance:
@@ -300,12 +300,12 @@ module Dir_params = struct
             (* A simple equation can't contain funcall -> ignore *)
             | Eqn (_, _, _) -> deq.content
             (* Reccursive call on loops *)
-            | Loop (i, ei, ef, dl, opts) ->
-                Ident.Hashtbl.add env_var i Nat;
+            | Loop t ->
+                Ident.Hashtbl.add env_var t.id Nat;
                 let res =
-                  Loop (i, ei, ef, fix_deqs env_fun env_var def dl, opts)
+                  Loop { t with body = fix_deqs env_fun env_var def t.body }
                 in
-                Ident.Hashtbl.remove env_var i;
+                Ident.Hashtbl.remove env_var t.id;
                 res);
         })
       deqs
@@ -434,12 +434,12 @@ module Dir_inner = struct
             (* A simple equation can't contain funcall -> ignore *)
             | Eqn (_, _, _) -> deq.content
             (* Reccursive call on loops *)
-            | Loop (i, ei, ef, dl, opts) ->
-                Ident.Hashtbl.add env_var i Nat;
+            | Loop t ->
+                Ident.Hashtbl.add env_var t.id Nat;
                 let res =
-                  Loop (i, ei, ef, fix_deqs env_fun env_var def dl, opts)
+                  Loop { t with body = fix_deqs env_fun env_var def t.body }
                 in
-                Ident.Hashtbl.remove env_var i;
+                Ident.Hashtbl.remove env_var t.id;
                 res);
         })
       deqs

--- a/src/normalization/mask.ml
+++ b/src/normalization/mask.ml
@@ -90,7 +90,7 @@ module Get_consts = struct
                   | None -> ()))
               lhs
               (expr_is_const env_fun env_const env_not_const e)
-        | Loop (_, _, _, _, _) -> assert false
+        | Loop _ -> assert false
         (* Loops have been unrolled *))
       deqs
 
@@ -202,20 +202,23 @@ let mask_var (env_var : typ Ident.Hashtbl.t) (env_const : bool Ident.Hashtbl.t)
               orig;
               content =
                 Loop
-                  ( loop_idx,
-                    Const_e 1,
-                    loop_end,
-                    [
-                      {
-                        orig;
-                        content =
-                          Eqn
-                            ( [ make_loop_indexed vl ],
-                              Const (0, Some typ),
-                              false );
-                      };
-                    ],
-                    [] );
+                  {
+                    id = loop_idx;
+                    start = Const_e 1;
+                    stop = loop_end;
+                    body =
+                      [
+                        {
+                          orig;
+                          content =
+                            Eqn
+                              ( [ make_loop_indexed vl ],
+                                Const (0, Some typ),
+                                false );
+                        };
+                      ];
+                    opts = [];
+                  };
             };
           ]
       | false ->
@@ -225,20 +228,23 @@ let mask_var (env_var : typ Ident.Hashtbl.t) (env_const : bool Ident.Hashtbl.t)
               orig;
               content =
                 Loop
-                  ( loop_idx,
-                    Const_e 0,
-                    loop_end,
-                    [
-                      {
-                        orig;
-                        content =
-                          Eqn
-                            ( [ make_loop_indexed vl ],
-                              ExpVar (make_loop_indexed ve),
-                              false );
-                      };
-                    ],
-                    [] );
+                  {
+                    id = loop_idx;
+                    start = Const_e 0;
+                    stop = loop_end;
+                    body =
+                      [
+                        {
+                          orig;
+                          content =
+                            Eqn
+                              ( [ make_loop_indexed vl ],
+                                ExpVar (make_loop_indexed ve),
+                                false );
+                        };
+                      ];
+                    opts = [];
+                  };
             };
           ])
 (*                                                            ^^^^^    ^^ *)
@@ -258,17 +264,20 @@ let mask_cst (env_const : bool Ident.Hashtbl.t) (orig : (ident * deq_i) list)
             orig;
             content =
               Loop
-                ( loop_idx,
-                  Const_e 0,
-                  loop_end,
-                  [
-                    {
-                      orig;
-                      content =
-                        Eqn ([ make_loop_indexed vl ], Const (0, typ), false);
-                    };
-                  ],
-                  [] );
+                {
+                  id = loop_idx;
+                  start = Const_e 0;
+                  stop = loop_end;
+                  body =
+                    [
+                      {
+                        orig;
+                        content =
+                          Eqn ([ make_loop_indexed vl ], Const (0, typ), false);
+                      };
+                    ];
+                  opts = [];
+                };
           };
         ]
       else
@@ -281,17 +290,20 @@ let mask_cst (env_const : bool Ident.Hashtbl.t) (orig : (ident * deq_i) list)
             orig;
             content =
               Loop
-                ( loop_idx,
-                  Const_e 1,
-                  loop_end,
-                  [
-                    {
-                      orig;
-                      content =
-                        Eqn ([ make_loop_indexed vl ], Const (0, typ), false);
-                    };
-                  ],
-                  [] );
+                {
+                  id = loop_idx;
+                  start = Const_e 1;
+                  stop = loop_end;
+                  body =
+                    [
+                      {
+                        orig;
+                        content =
+                          Eqn ([ make_loop_indexed vl ], Const (0, typ), false);
+                      };
+                    ];
+                  opts = [];
+                };
           };
         ]
 
@@ -319,20 +331,23 @@ let mask_shift (env_var : typ Ident.Hashtbl.t)
               orig;
               content =
                 Loop
-                  ( loop_idx,
-                    Const_e 1,
-                    loop_end,
-                    [
-                      {
-                        orig;
-                        content =
-                          Eqn
-                            ( [ make_loop_indexed vl ],
-                              Const (0, Some typ),
-                              false );
-                      };
-                    ],
-                    [] );
+                  {
+                    id = loop_idx;
+                    start = Const_e 1;
+                    stop = loop_end;
+                    body =
+                      [
+                        {
+                          orig;
+                          content =
+                            Eqn
+                              ( [ make_loop_indexed vl ],
+                                Const (0, Some typ),
+                                false );
+                        };
+                      ];
+                    opts = [];
+                  };
             };
           ]
       | false ->
@@ -342,20 +357,23 @@ let mask_shift (env_var : typ Ident.Hashtbl.t)
               orig;
               content =
                 Loop
-                  ( loop_idx,
-                    Const_e 0,
-                    loop_end,
-                    [
-                      {
-                        orig;
-                        content =
-                          Eqn
-                            ( [ make_loop_indexed vl ],
-                              Shift (op, ExpVar (make_loop_indexed ve), ae),
-                              false );
-                      };
-                    ],
-                    [] );
+                  {
+                    id = loop_idx;
+                    start = Const_e 0;
+                    stop = loop_end;
+                    body =
+                      [
+                        {
+                          orig;
+                          content =
+                            Eqn
+                              ( [ make_loop_indexed vl ],
+                                Shift (op, ExpVar (make_loop_indexed ve), ae),
+                                false );
+                        };
+                      ];
+                    opts = [];
+                  };
             };
           ])
 
@@ -385,20 +403,23 @@ let mask_not (env_var : typ Ident.Hashtbl.t) (env_const : bool Ident.Hashtbl.t)
               orig;
               content =
                 Loop
-                  ( loop_idx,
-                    Const_e 1,
-                    loop_end,
-                    [
-                      {
-                        orig;
-                        content =
-                          Eqn
-                            ( [ make_loop_indexed vl ],
-                              Const (0, Some typ),
-                              false );
-                      };
-                    ],
-                    [] );
+                  {
+                    id = loop_idx;
+                    start = Const_e 1;
+                    stop = loop_end;
+                    body =
+                      [
+                        {
+                          orig;
+                          content =
+                            Eqn
+                              ( [ make_loop_indexed vl ],
+                                Const (0, Some typ),
+                                false );
+                        };
+                      ];
+                    opts = [];
+                  };
             };
           ]
       | false ->
@@ -416,20 +437,23 @@ let mask_not (env_var : typ Ident.Hashtbl.t) (env_const : bool Ident.Hashtbl.t)
               orig;
               content =
                 Loop
-                  ( loop_idx,
-                    Const_e 1,
-                    loop_end,
-                    [
-                      {
-                        orig;
-                        content =
-                          Eqn
-                            ( [ make_loop_indexed vl ],
-                              ExpVar (make_loop_indexed ve),
-                              false );
-                      };
-                    ],
-                    [] );
+                  {
+                    id = loop_idx;
+                    start = Const_e 1;
+                    stop = loop_end;
+                    body =
+                      [
+                        {
+                          orig;
+                          content =
+                            Eqn
+                              ( [ make_loop_indexed vl ],
+                                ExpVar (make_loop_indexed ve),
+                                false );
+                        };
+                      ];
+                    opts = [];
+                  };
             };
           ])
 
@@ -462,23 +486,26 @@ let mask_xor (env_var : typ Ident.Hashtbl.t) (env_const : bool Ident.Hashtbl.t)
               orig;
               content =
                 Loop
-                  ( loop_idx,
-                    Const_e 0,
-                    loop_end,
-                    [
-                      {
-                        orig;
-                        content =
-                          Eqn
-                            ( [ make_loop_indexed vl ],
-                              Log
-                                ( Xor,
-                                  ExpVar (make_loop_indexed x),
-                                  ExpVar (make_loop_indexed y) ),
-                              false );
-                      };
-                    ],
-                    [] );
+                  {
+                    id = loop_idx;
+                    start = Const_e 0;
+                    stop = loop_end;
+                    body =
+                      [
+                        {
+                          orig;
+                          content =
+                            Eqn
+                              ( [ make_loop_indexed vl ],
+                                Log
+                                  ( Xor,
+                                    ExpVar (make_loop_indexed x),
+                                    ExpVar (make_loop_indexed y) ),
+                                false );
+                        };
+                      ];
+                    opts = [];
+                  };
             };
           ])
   | One -> (
@@ -503,23 +530,26 @@ let mask_xor (env_var : typ Ident.Hashtbl.t) (env_const : bool Ident.Hashtbl.t)
               orig;
               content =
                 Loop
-                  ( loop_idx,
-                    Const_e 1,
-                    loop_end,
-                    [
-                      {
-                        orig;
-                        content =
-                          Eqn
-                            ( [ make_loop_indexed vl ],
-                              Log
-                                ( Xor,
-                                  ExpVar (make_loop_indexed x),
-                                  Const (0, Some typ) ),
-                              false );
-                      };
-                    ],
-                    [] );
+                  {
+                    id = loop_idx;
+                    start = Const_e 1;
+                    stop = loop_end;
+                    body =
+                      [
+                        {
+                          orig;
+                          content =
+                            Eqn
+                              ( [ make_loop_indexed vl ],
+                                Log
+                                  ( Xor,
+                                    ExpVar (make_loop_indexed x),
+                                    Const (0, Some typ) ),
+                                false );
+                        };
+                      ];
+                    opts = [];
+                  };
             };
           ])
   | Two -> (
@@ -548,20 +578,23 @@ let mask_xor (env_var : typ Ident.Hashtbl.t) (env_const : bool Ident.Hashtbl.t)
               orig;
               content =
                 Loop
-                  ( loop_idx,
-                    Const_e 1,
-                    loop_end,
-                    [
-                      {
-                        orig;
-                        content =
-                          Eqn
-                            ( [ make_loop_indexed vl ],
-                              Const (0, Some typ),
-                              false );
-                      };
-                    ],
-                    [] );
+                  {
+                    id = loop_idx;
+                    start = Const_e 1;
+                    stop = loop_end;
+                    body =
+                      [
+                        {
+                          orig;
+                          content =
+                            Eqn
+                              ( [ make_loop_indexed vl ],
+                                Const (0, Some typ),
+                                false );
+                        };
+                      ];
+                    opts = [];
+                  };
             };
           ])
 
@@ -607,20 +640,23 @@ let mask_and_or (env_var : typ Ident.Hashtbl.t)
               orig;
               content =
                 Loop
-                  ( loop_idx,
-                    Const_e 0,
-                    loop_end,
-                    [
-                      {
-                        orig;
-                        content =
-                          Eqn
-                            ( [ make_loop_indexed vl ],
-                              Log (op, ExpVar (make_loop_indexed x), ExpVar y),
-                              false );
-                      };
-                    ],
-                    [] );
+                  {
+                    id = loop_idx;
+                    start = Const_e 0;
+                    stop = loop_end;
+                    body =
+                      [
+                        {
+                          orig;
+                          content =
+                            Eqn
+                              ( [ make_loop_indexed vl ],
+                                Log (op, ExpVar (make_loop_indexed x), ExpVar y),
+                                false );
+                        };
+                      ];
+                    opts = [];
+                  };
             };
           ])
   | Two -> (
@@ -649,20 +685,23 @@ let mask_and_or (env_var : typ Ident.Hashtbl.t)
               orig;
               content =
                 Loop
-                  ( loop_idx,
-                    Const_e 1,
-                    loop_end,
-                    [
-                      {
-                        orig;
-                        content =
-                          Eqn
-                            ( [ make_loop_indexed vl ],
-                              Const (0, Some typ),
-                              false );
-                      };
-                    ],
-                    [] );
+                  {
+                    id = loop_idx;
+                    start = Const_e 1;
+                    stop = loop_end;
+                    body =
+                      [
+                        {
+                          orig;
+                          content =
+                            Eqn
+                              ( [ make_loop_indexed vl ],
+                                Const (0, Some typ),
+                                false );
+                        };
+                      ];
+                    opts = [];
+                  };
             };
           ])
 
@@ -697,11 +736,12 @@ let rec mask_deqs (env_var : typ Ident.Hashtbl.t)
           [ { d with content = Eqn (lhs, Fun (f, l), sync) } ]
       | Eqn ([ lv ], e, _) -> mask_eqn env_var env_const d.orig lv e
       | Eqn _ -> assert false (* Not normalized *)
-      | Loop (i, ei, ef, dl, sync) ->
+      | Loop t ->
           [
             {
               d with
-              content = Loop (i, ei, ef, mask_deqs env_var env_const dl, sync);
+              content =
+                Loop { t with body = mask_deqs env_var env_const t.body };
             };
           ])
     deqs

--- a/src/normalization/norm_tuples.ml
+++ b/src/normalization/norm_tuples.ml
@@ -64,7 +64,7 @@ module Simplify_tuples = struct
           content =
             (match d.content with
             | Eqn (p, e, sync) -> Eqn (p, expr_from_list (simpl_tuple e), sync)
-            | Loop (i, ei, ef, dl, opts) -> Loop (i, ei, ef, simpl_deqs dl, opts));
+            | Loop t -> Loop { t with body = simpl_deqs t.body });
         })
       deq
 
@@ -113,17 +113,17 @@ module Split_tuples = struct
         | Eqn (p, e, sync) ->
             if contains_fun e then [ d ]
             else real_split_tuple env d.orig p e sync
-        | Loop (i, ei, ef, dl, opts) ->
-            Ident.Hashtbl.add env i Nat;
+        | Loop t ->
+            Ident.Hashtbl.add env t.id Nat;
             let res =
               [
                 {
                   d with
-                  content = Loop (i, ei, ef, split_tuples_deq env dl, opts);
+                  content = Loop { t with body = split_tuples_deq env t.body };
                 };
               ]
             in
-            Ident.Hashtbl.remove env i;
+            Ident.Hashtbl.remove env t.id;
             res)
       body
 

--- a/src/normalization/normalize.ml
+++ b/src/normalization/normalize.ml
@@ -110,6 +110,5 @@ let optimize prog conf =
 
 let compile prog (conf : Config.config) =
   let normalized = norm_prog true prog conf in
-
   (* Get_live_var.run normalized; *)
   optimize normalized conf

--- a/src/normalization/remove_sync.ml
+++ b/src/normalization/remove_sync.ml
@@ -154,12 +154,12 @@ let rec clean_deqs (env_var : typ Ident.Hashtbl.t)
         d with
         content =
           (match d.content with
-          | Loop (x, ei, ef, dl, opts) ->
-              Ident.Hashtbl.add env_var x Nat;
+          | Loop t ->
+              Ident.Hashtbl.add env_var t.id Nat;
               let res =
-                Loop (x, ei, ef, clean_deqs env_var env_replace dl, opts)
+                Loop { t with body = clean_deqs env_var env_replace t.body }
               in
-              Ident.Hashtbl.remove env_var x;
+              Ident.Hashtbl.remove env_var t.id;
               res
           | Eqn (lhs, e, sync) -> (
               let e' = clean_expr env_var env_replace e in

--- a/src/normalization/shift_tuples.ml
+++ b/src/normalization/shift_tuples.ml
@@ -93,8 +93,7 @@ let rec shift_deq (env_var : typ Ident.Hashtbl.t) (deq : deq) : deq =
     content =
       (match deq.content with
       | Eqn (p, e, sync) -> Eqn (p, shift_expr env_var e, sync)
-      | Loop (id, ei, ef, d, opts) ->
-          Loop (id, ei, ef, List.map (shift_deq env_var) d, opts));
+      | Loop t -> Loop { t with body = List.map (shift_deq env_var) t.body });
   }
 
 let shift_def (def : def) : def =

--- a/src/normalization/unfold_unnest.ml
+++ b/src/normalization/unfold_unnest.ml
@@ -334,20 +334,19 @@ let rec norm_deq env_var env_fun (its : (ident * int) list) (body : deq list) :
               let m = Utils.get_type_m t in
               let expr_l, e' = norm_expr env_var env_fun its (dir, m) ltyp e in
               expr_l @ [ { d with content = Eqn (lhs, e', sync) } ])
-      | Loop (x, ei, ef, dl, opts) ->
+      | Loop t ->
           let size =
-            abs (Utils.eval_arith_ne ei - Utils.eval_arith_ne ef) + 1
+            abs (Utils.eval_arith_ne t.start - Utils.eval_arith_ne t.stop) + 1
           in
           [
             {
               d with
               content =
                 Loop
-                  ( x,
-                    ei,
-                    ef,
-                    norm_deq env_var env_fun ((x, size) :: its) dl,
-                    opts );
+                  {
+                    t with
+                    body = norm_deq env_var env_fun ((t.id, size) :: its) t.body;
+                  };
             };
           ])
     body

--- a/src/normalization/unroll.ml
+++ b/src/normalization/unroll.ml
@@ -62,22 +62,23 @@ let rec unroll_deqs (env_it : int Ident.Hashtbl.t) (force : bool) (f : ident)
           in
 
           [ { orig = new_orig; content = new_eqn } ]
-      | Loop (i, ei, ef, dl, opts) ->
-          if force || is_unroll opts then
-            let ei = eval_arith env_it ei in
-            let ef = eval_arith env_it ef in
+      | Loop t ->
+          if force || is_unroll t.opts then
+            let start = eval_arith env_it t.start in
+            let stop = eval_arith env_it t.stop in
             flat_map
               (fun n ->
-                Ident.Hashtbl.add env_it i n;
-                let res = unroll_deqs env_it force f dl in
-                Ident.Hashtbl.remove env_it i;
+                Ident.Hashtbl.add env_it t.id n;
+                let res = unroll_deqs env_it force f t.body in
+                Ident.Hashtbl.remove env_it t.id;
                 res)
-              (gen_list_bounds ei ef)
+              (gen_list_bounds start stop)
           else
             [
               {
                 orig = deq.orig;
-                content = Loop (i, ei, ef, unroll_deqs env_it force f dl, opts);
+                content =
+                  Loop { t with body = unroll_deqs env_it force f t.body };
               };
             ])
     deqs

--- a/src/optimization/CSE.ml
+++ b/src/optimization/CSE.ml
@@ -104,11 +104,14 @@ let rec cse_deqs (env_expr : var list ExprHashtbl.t) (deqs : deq list) :
               | Some _ -> ()
               | None -> ExprHashtbl.add env_expr e' lhs));
           { d with content = Eqn (lhs, e', sync) }
-      | Loop (i, ei, ef, dl, opts) ->
+      | Loop t ->
           (* Passing a copy of |env_expr| to the loop, so that nothing
              from the loop's body leaks outside. *)
           let env_expr_copy = ExprHashtbl.copy env_expr in
-          { d with content = Loop (i, ei, ef, cse_deqs env_expr_copy dl, opts) })
+          {
+            d with
+            content = Loop { t with body = cse_deqs env_expr_copy t.body };
+          })
     deqs
 
 let cse_def (def : def) : def =

--- a/src/optimization/constant_folding.ml
+++ b/src/optimization/constant_folding.ml
@@ -203,8 +203,8 @@ let rec fold_deqs (env_var : typ Ident.Hashtbl.t) (deqs : deq list) : deq list =
       match d.content with
       | Eqn (lhs, e, sync) ->
           { d with content = Eqn (lhs, fold_expr env_var e, sync) }
-      | Loop (i, ei, ef, dl, opts) ->
-          { d with content = Loop (i, ei, ef, fold_deqs env_var dl, opts) })
+      | Loop t ->
+          { d with content = Loop { t with body = fold_deqs env_var t.body } })
     deqs
 
 let fold_def (def : def) : def =

--- a/src/optimization/inline.ml
+++ b/src/optimization/inline.ml
@@ -49,7 +49,7 @@ module Is_linear = struct
       (fun deq ->
         match deq.content with
         | Eqn (_, e, _) -> is_linear_expr env_fun e
-        | Loop (_, _, _, dl, _) -> is_linear_deqs env_fun dl)
+        | Loop { body; _ } -> is_linear_deqs env_fun body)
       deqs
 
   and is_linear_def_i (env_fun : (string, def) Hashtbl.t) (def_i : def_i) : bool
@@ -96,8 +96,8 @@ let is_more_than_n_percent_assign (n : int) (deqs : deq list) : bool =
       (fun (asgns, tot) deq ->
         match deq.content with
         | Eqn (_, ExpVar _, _) -> (asgns + 1, tot + 1)
-        | Loop (_, _, _, dl, _) ->
-            let asgns', tot' = get_assigns dl in
+        | Loop { body; _ } ->
+            let asgns', tot' = get_assigns body in
             (asgns + asgns', tot + tot')
         | _ -> (asgns, tot + 1))
       (0, 0) deqs
@@ -150,7 +150,7 @@ let rec is_call_free env inlined conf (def : def) : bool =
         if String.equal (Ident.name f) "refresh" then true
         else not (can_inline env inlined conf (Hashtbl.find env (Ident.name f)))
     | Eqn _ -> true
-    | Loop (_, _, _, dl, _) -> List.for_all deq_call_free dl
+    | Loop { body; _ } -> List.for_all deq_call_free body
   in
   match def.node with
   | Single (_, body) -> List.for_all deq_call_free body

--- a/src/optimization/interleave.ml
+++ b/src/optimization/interleave.ml
@@ -186,7 +186,7 @@ module Interleave_generic = struct
                       };
                     ]
                   @ aux grain [] nexts_tl
-              | Loop (i, ei, ef, dls, opts) ->
+              | Loop t ->
                   (* A loop -> need to schedule |ready| now, duplicate
                      the loops body, and continue with the next
                      instructions. *)
@@ -194,7 +194,7 @@ module Interleave_generic = struct
                   @ [
                       {
                         nexts_hd with
-                        content = Loop (i, ei, ef, aux grain [] dls, opts);
+                        content = Loop { t with body = aux grain [] t.body };
                       };
                     ]
                   @ aux grain [] nexts_tl
@@ -322,8 +322,10 @@ module Dup3 = struct
                 content = Eqn (List.map dup3_var lhs, dup3_expr e, sync);
               };
             ]
-        | Loop (i, ei, ef, l, opts) ->
-            [ { d with content = Loop (i, ei, ef, interleave_deqs l, opts) } ])
+        | Loop t ->
+            [
+              { d with content = Loop { t with body = interleave_deqs t.body } };
+            ])
       deqs
 
   let dup_p (p : p) : p =
@@ -388,11 +390,11 @@ module Dup2 = struct
                 content = Eqn (List.map dup_var lhs, dup_expr e, sync);
               };
             ]
-        | Loop (i, ei, ef, l, opts) ->
+        | Loop t ->
             [
               {
                 orig = d.orig;
-                content = Loop (i, ei, ef, interleave_deqs l, opts);
+                content = Loop { t with body = interleave_deqs t.body };
               };
             ])
       deqs
@@ -473,8 +475,10 @@ module Dup2_nofunc = struct
                       Eqn (List.map make_2nd_var lhs, make_2nd_expr e, sync);
                   };
                 ])
-        | Loop (i, ei, ef, l, opts) ->
-            [ { d with content = Loop (i, ei, ef, interleave_deqs l, opts) } ])
+        | Loop t ->
+            [
+              { d with content = Loop { t with body = interleave_deqs t.body } };
+            ])
       deqs
 
   let dup_p (p : p) : p =
@@ -621,12 +625,13 @@ module Dup2_nofunc_param = struct
                             make_2nd_expr env_var e,
                             sync );
                     } ))
-        | Loop (i, ei, ef, l, opts) ->
+        | Loop t ->
             ( None,
               Some
                 {
                   d with
-                  content = Loop (i, ei, ef, interleave_deqs env_var g l, opts);
+                  content =
+                    Loop { t with body = interleave_deqs env_var g t.body };
                 } ))
       deqs
 

--- a/src/optimization/remove_dead_code.ml
+++ b/src/optimization/remove_dead_code.ml
@@ -66,7 +66,7 @@ module Find_used_variables = struct
                       updated := true;
                       Ident.Hashtbl.replace used_vars (get_base_name v) true)
                 (get_used_vars e))
-        | Loop (_, _, _, dl, _) -> find_used_in_deqs used_vars (List.rev dl))
+        | Loop { body; _ } -> find_used_in_deqs used_vars (List.rev body))
       deqs
 
   let find_used_variables (def : def) : bool Ident.Hashtbl.t =
@@ -102,14 +102,13 @@ let rec remove_dead_deqs (used_vars : bool Ident.Hashtbl.t) (deqs : deq list) :
             [ { d with content = Eqn (lhs, e, sync) } ]
           else (* Unused equation, removing it *)
             []
-      | Loop (i, ei, ef, dl, opts) -> (
-          let dl' = remove_dead_deqs used_vars dl in
-          (* if |dl'| is empty, removing the loop altogether. *)
-          match dl' with
+      | Loop t -> (
+          match remove_dead_deqs used_vars t.body with
+          (* if |body| is empty, removing the loop altogether. *)
           | [] -> []
-          | _ ->
+          | body ->
               (* |dl'| not empty, keeping the loop *)
-              [ { d with content = Loop (i, ei, ef, dl', opts) } ]))
+              [ { d with content = Loop { t with body } } ]))
     deqs
 
 let remove_dead_code_def (def : def) : def =

--- a/src/optimization/scheduler.ml
+++ b/src/optimization/scheduler.ml
@@ -393,10 +393,11 @@ module Low_pressure_sched = struct
   let rec inner_sched env_var (parallel_lvl : int) (deq : deq) : deq =
     match deq.content with
     | Eqn _ -> deq
-    | Loop (x, ei, ef, dl, opts) ->
+    | Loop t ->
         {
           deq with
-          content = Loop (x, ei, ef, schedule_deqs env_var parallel_lvl dl, opts);
+          content =
+            Loop { t with body = schedule_deqs env_var parallel_lvl t.body };
         }
 
   and schedule_deqs env_var (parallel_lvl : int) (deqs : deq list) : deq list =

--- a/src/optimization/vital_inline.ml
+++ b/src/optimization/vital_inline.ml
@@ -56,7 +56,7 @@ module Must_inline = struct
       (fun d ->
         match d.content with
         | Eqn (_, e, _) -> must_inline_expr env_var env_in e
-        | Loop (_, _, _, dl, _) -> must_inline_deqs env_var env_in dl)
+        | Loop { body; _ } -> must_inline_deqs env_var env_in body)
       deqs
 
   let must_inline_def (def : def) : bool =

--- a/src/parsing/parser.mly
+++ b/src/parsing/parser.mly
@@ -173,9 +173,9 @@ opt_stmt:
    | PIPELINED { Pipelined }
 
 %public deq_forall:
- | opts = list(opt_stmt) FORALL id = ident IN LBRACKET startae = arith_exp
-   COMMA endae = arith_exp RBRACKET LCURLY d = deqs RCURLY
-    { { content = Loop(id, startae, endae, d, opts); orig = [] } }
+ | opts = list(opt_stmt) FORALL id = ident IN LBRACKET start = arith_exp
+   COMMA stop = arith_exp RBRACKET LCURLY body = deqs RCURLY
+    { { content = Loop {id; start; stop; body; opts}; orig = [] } }
 
 (* Doesn't use the |deq| rule because it would make semicolons mandatory after
    foralls. *)

--- a/src/parsing/parser_api.ml
+++ b/src/parsing/parser_api.ml
@@ -1,5 +1,4 @@
 open Prelude
-open Lexer
 open Lexing
 open Usuba_AST
 module I = Parser.MenhirInterpreter

--- a/src/rename.ml
+++ b/src/rename.ml
@@ -73,10 +73,10 @@ let rec rename_deq map deqs =
           (match d.content with
           | Eqn (pat, expr, sync) ->
               Eqn (rename_pat map pat, rename_expr map expr, sync)
-          | Loop (id, ei, ef, d, opts) ->
-              let new_id = Ident.fresh_suffixed id "'" in
-              let map = Ident.Map.add id new_id map in
-              Loop (new_id, ei, ef, rename_deq map d, opts));
+          | Loop t ->
+              let id = Ident.fresh_suffixed t.id "'" in
+              let map = Ident.Map.add t.id id map in
+              Loop { t with id; body = rename_deq map t.body });
       })
     deqs
 

--- a/src/tightprove/tightprove.ml
+++ b/src/tightprove/tightprove.ml
@@ -223,8 +223,11 @@ module Refresh = struct
             (* Keep searching*)
             match hd.content with
             | Eqn _ -> hd :: find_deq_in_f tl
-            | Loop (i, ei, ef, dl, opts) ->
-                { hd with content = Loop (i, ei, ef, find_deq_in_f dl, opts) }
+            | Loop t ->
+                {
+                  hd with
+                  content = Loop { t with body = find_deq_in_f t.body };
+                }
                 ::
                 (if !is_found then
                  (* |old_first_use_deq| was found inside the loop
@@ -294,8 +297,8 @@ module Refresh = struct
                    skip in |f|. *)
                 full_prog := List.tl !full_prog;
                 update_f_body f_body)
-          | Loop (i, ei, ef, dl, opts) ->
-              { hd with content = Loop (i, ei, ef, update_f_body dl, opts) }
+          | Loop t ->
+              { hd with content = Loop { t with body = update_f_body t.body } }
               :: update_f_body tl)
     in
 
@@ -491,7 +494,7 @@ let is_call_and_loop_free (def : def) : bool =
     | Eqn (_, Fun (f, _), _) ->
         if String.equal (Ident.name f) "refresh" then true else false
     | Eqn _ -> true
-    | Loop (_, _, _, _, _) -> false
+    | Loop _ -> false
   in
   match def.node with
   | Single (_, body) -> List.for_all deq_call_free body

--- a/src/usuba_AST.mli
+++ b/src/usuba_AST.mli
@@ -83,11 +83,17 @@ type stmt_opt = Unroll | No_unroll | Pipelined | Safe_exit
 
 (** The type of equations:
     - [Eqn] a simple equation ({i i.e. [x = a + b]})
-    - [Loop _ start stop dl _] a for loop from [start] to [stop] of [Eqn] or [Loop]
+    - [Loop _ start stop body _] a for loop from [start] to [stop] of [Eqn] or [Loop]
  *)
 type deq_i =
   | Eqn of var list * expr * bool
-  | Loop of ident * arith_expr * arith_expr * deq list * stmt_opt list
+  | Loop of {
+      id : ident;
+      start : arith_expr;
+      stop : arith_expr;
+      body : deq list;
+      opts : stmt_opt list;
+    }
 
 and deq = {
   content : deq_i;

--- a/src/usuba_print.ml
+++ b/src/usuba_print.ml
@@ -269,18 +269,18 @@ let rec pp_deq_i ?(typed = false) ?(detailed = false) () ppf (deq_i : deq_i) =
         (if sync then ":" else "")
         (pp_expr ~typed ~detailed ())
         e
-  | Loop (id, ei, ef, d, opts) ->
+  | Loop { id; start; stop; body; opts } ->
       Format.fprintf ppf
         "@[<v 0>@[<v 2>%a%sforall %a in [%a,%a] {@,@[<v 2>%a@]@]@,}@]"
         (pp_list_space pp_optstmt) opts
         (if List.length opts > 0 then " " else "")
         (Ident.pp ~detailed ()) id
         (pp_arith ~typed ~detailed ())
-        ei
+        start
         (pp_arith ~typed ~detailed ())
-        ef
+        stop
         (pp_list_semi_cut (pp_deq ~detailed ()))
-        d
+        body
 
 and pp_deq ?(typed = false) ?(detailed = false) () ppf (deq : deq) =
   pp_deq_i ~detailed ~typed () ppf deq.content

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -455,7 +455,7 @@ let rec get_used_vars (e : expr) : var list =
 let rec get_used_vars_deq (deq : deq) : var list =
   match deq.content with
   | Eqn (_, e, _) -> get_used_vars e
-  | Loop (_, _, _, dl, _) -> flat_map get_used_vars_deq dl
+  | Loop { body; _ } -> flat_map get_used_vars_deq body
 
 let rec get_var_name (v : var) : ident =
   match v with

--- a/src/verification/variable_binding.ml
+++ b/src/verification/variable_binding.ml
@@ -121,20 +121,20 @@ let rec bind_deqs ~conf ~backtrace ~vars_env ~fun_env body =
           let vs = List.map (bind_var ~backtrace vars_env) vs in
           let e = bind_expr ~conf ~backtrace ~vars_env ~fun_env e in
           { deq with content = Eqn (vs, e, sync) }
-      | Loop (id, ei, ef, dl, opts) ->
+      | Loop { id; start; stop; body; opts } ->
           let backtrace =
             Format.asprintf "  deq = forall %a in [%a, %a] { ... }"
-              (Ident.pp ()) id (Usuba_print.pp_arith ()) ei
-              (Usuba_print.pp_arith ()) ef
+              (Ident.pp ()) id (Usuba_print.pp_arith ()) start
+              (Usuba_print.pp_arith ()) stop
             :: backtrace
           in
           let vars_env, id =
             Bindings.refresh_id_and_store ~conf ~backtrace ~id vars_env
           in
-          let ei = bind_arith ~backtrace ~vars_env ei in
-          let ef = bind_arith ~backtrace ~vars_env ef in
-          let dl = bind_deqs ~conf ~backtrace ~vars_env ~fun_env dl in
-          { deq with content = Loop (id, ei, ef, dl, opts) })
+          let start = bind_arith ~backtrace ~vars_env start in
+          let stop = bind_arith ~backtrace ~vars_env stop in
+          let body = bind_deqs ~conf ~backtrace ~vars_env ~fun_env body in
+          { deq with content = Loop { id; start; stop; body; opts } })
     body
 
 module Var_d = struct


### PR DESCRIPTION
Update of Loop types to contain an inline record instead of a tuple

It should now be easier to edit the code parts where Loop is transformed in a record.